### PR TITLE
Fixing softmax_cross_entropy_with_logits syntax in deep-mnist network.py

### DIFF
--- a/experiments/deep-mnist/deep-mnist.py
+++ b/experiments/deep-mnist/deep-mnist.py
@@ -16,7 +16,7 @@ flags.DEFINE_integer('minibatches', 20000, 'Number of minibatches to run the tra
 flags.DEFINE_integer('minibatch_size', 50, 'Number of samples in each minibatch.')
 flags.DEFINE_float('learning_rate', 0.001, 'Learning rate of the optimizer.')
 flags.DEFINE_integer('status_update', 100, 'How often to print an status update.')
-flags.DEFINE_string('optimizer', 'gradent_descent', 'If another optimizer should be used [adam, rmsprop]. Defaults to gradient descent')
+flags.DEFINE_string('optimizer', 'gradient_descent', 'If another optimizer should be used [adam, rmsprop]. Defaults to gradient descent')
 flags.DEFINE_integer('random_seed', 123, 'Sets the random seed.')
 flags.DEFINE_boolean('run_test', True, 'If the final model should be tested')
 flags.DEFINE_boolean('use_gpu', False, 'If it should run the TensorFlow operations on the GPU rather than the CPU.')

--- a/experiments/deep-mnist/network.py
+++ b/experiments/deep-mnist/network.py
@@ -101,7 +101,7 @@ class ConvolutionalNeuralNetwork(object):
 
             # Objective/Error function - Cross Entropy
             with tf.name_scope('loss') as scope:
-                self.obj_function = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(self.y, self.y_))
+                self.obj_function = tf.reduce_mean(tf.nn.softmax_cross_entropy_with_logits(logits=self.y, labels=self.y_))
 
             with tf.name_scope('train') as scope:
                 if optimizer.lower() == 'adam':

--- a/experiments/mnist/mnist.py
+++ b/experiments/mnist/mnist.py
@@ -17,7 +17,7 @@ flags.DEFINE_integer('minibatch_size', 100, 'Number of samples in each minibatch
 flags.DEFINE_float('learning_rate', 0.5, 'Learning rate of the optimizer.')
 flags.DEFINE_integer('status_update', 100, 'How often to print an status update.')
 flags.DEFINE_integer('random_seed', 123, 'Sets the random seed.')
-flags.DEFINE_string('optimizer', 'gradent_descent', 'Specifices optimizer to use [adam, rmsprop]. Defaults to gradient descent')
+flags.DEFINE_string('optimizer', 'gradient_descent', 'Specifices optimizer to use [adam, rmsprop]. Defaults to gradient descent')
 flags.DEFINE_boolean('run_test', True, 'If the final model should be tested')
 flags.DEFINE_boolean('use_gpu', False, 'If it should run the TensorFlow operations on the GPU rather than the CPU.')
 

--- a/experiments/xor/xor.py
+++ b/experiments/xor/xor.py
@@ -14,7 +14,7 @@ flags.DEFINE_integer('hidden_n', 2, 'Number of nodes to use in the two hidden la
 flags.DEFINE_float('learning_rate', 0.1, 'Learning rate of the optimizer.')
 flags.DEFINE_integer('status_update', 1000, 'How often to print an status update.')
 flags.DEFINE_integer('random_seed', 123, 'Sets the random seed.')
-flags.DEFINE_string('optimizer', 'gradent_descent', 'Specifices optimizer to use [adam, rmsprop]. Defaults to gradient descent')
+flags.DEFINE_string('optimizer', 'gradient_descent', 'Specifices optimizer to use [adam, rmsprop]. Defaults to gradient descent')
 flags.DEFINE_boolean('run_test', True, 'If the final model should be tested.')
 
 settings = flags.FLAGS


### PR DESCRIPTION
ValueError: Only call `softmax_cross_entropy_with_logits` with named arguments (logits=..., labels=..., ...)

Was getting this error. Updated the syntax. Works after this fix.